### PR TITLE
[WIP] Added functions for building and reading packets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 [How to Run]
 
 Run from project root directory, eIRC/ then:
-
+```
 * Client: $ python -m src.client.client <arguments>
 
 * Server: $ python -m src.server.server --hostname localhost --port 8888 --maxconns 32 --messagelength 64
-
+```
 
 This is so that we can utilize build_packet which is located in src/utils
 
+```
 [Directory Structure]
 src/                        <- Run application from here
 ├── client/
@@ -20,3 +21,4 @@ src/                        <- Run application from here
 └── utils/
     ├── __init__.py
     └── packet.py
+```


### PR DESCRIPTION
utils/packet.py -> { build_packet(str, str) -> bytes | unpack_packet(bytes) -> dict }. 

NOTE: Turned src into a package, this allows server and client to seamlessly utilize functionalities from utils/. 

NOTE: To run the applications, run from project root directory, eIRC, then  src.client.client <arguments> , likewise for server  src.server.server <arguments> .

 This is a necessity such that the absolute paths utilized by the logger object does not run from the subdirectories.