### PR TITLE
Penguin - Working server hopping (join and leave)

### DIFF
--- a/src/server/main.py
+++ b/src/server/main.py
@@ -110,6 +110,7 @@ class TrackerDaemon:
                     
                     match command:
 
+                        # Create a chat room
                         case "/create":
 
                             if len(args) < 2:
@@ -141,6 +142,7 @@ class TrackerDaemon:
                             packet = build_packet("CHAT CREATED", f"{name} {self.host} {chat_port}")
                             conn.send(packet)
 
+                        # List active servers
                         case "/list":
 
                             servers = self.tracker.get_server_list()
@@ -151,7 +153,7 @@ class TrackerDaemon:
                             packet = build_packet("/list", resp)
                             conn.send(packet)
 
-
+                        # Join a chat room
                         case "/join":
 
                             if len(args) < 1:
@@ -163,7 +165,6 @@ class TrackerDaemon:
                             servers = self.tracker.get_server_list()    # <- This is a dict()
                             
                             if name in servers:
-
                                 packet = build_packet("JOIN", f"{servers[name]}")
                                 print(f"JOIN: {servers[name]} @ {servers[name]}")
                                 conn.send(packet)
@@ -172,7 +173,19 @@ class TrackerDaemon:
                                 packet = build_packet("ERROR", "Server not found")
                                 conn.send(packet)
 
+                        # Exit tracker
+                        case "/exit":
 
+                            packet = build_packet("EXIT", "Closing connection...")
+                            conn.send(packet)
+                            try:
+                                conn.close()
+                                break
+                            except Exception as e:
+                                print(f"\nFailed to close connection: {e}")
+
+
+                        # Handle everything else
                         case _:
                             packet = build_packet("ERROR", "Unknown command")
                             conn.send(packet)

--- a/src/server/main.py
+++ b/src/server/main.py
@@ -130,6 +130,7 @@ class TrackerDaemon:
 
                             # register in tracker
                             admin_address = f"{addr[0]}:{addr[1]}"
+                            
                             self.tracker.register_server(
                                 name,
                                 f"{self.host}:{chat_port}",
@@ -143,14 +144,14 @@ class TrackerDaemon:
                             conn.send(packet)
 
                         # List active servers
-                        case "/list":
+                        case "/servers":
 
                             servers = self.tracker.get_server_list()
                             resp = "ACTIVE_SERVERS\n"
                             for sname, saddr in servers.items():
                                 resp += f"{sname} @ {saddr}\n"
 
-                            packet = build_packet("/list", resp)
+                            packet = build_packet("/servers", resp)
                             conn.send(packet)
 
                         # Join a chat room

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -57,6 +57,22 @@ class Server(threading.Thread):
     # Handling Messages From Clients
     def handle(self, client):
 
+
+        def handle_client_leave():
+
+                if client in self.clients:
+                    # Removing And Closing Clients
+                    index = self.clients.index(client)
+                    self.clients.remove(client)
+
+                    client.close()
+                    
+                    user = self.usernames[index]
+                    self.broadcast('{} left!'.format(user).encode('ascii'))
+                    self.usernames.remove(user)
+            # eo if
+        # eo def
+
         while True:
             
             try:
@@ -71,6 +87,19 @@ class Server(threading.Thread):
                 # The start of a message/body starts with '/' if it's a command
                 if body.startswith('/'):
                     print(f"Command: {body}")
+                    
+                    # Let's match the chat server commands
+                    match body:
+
+                        case "/leave":
+                            handle_client_leave()
+                            break
+                    
+                        case _:
+                            print(f"Unhandled command: {body}")
+
+                    # eo match
+                # eo if
 
                 message = header + ': ' + body
 
@@ -80,14 +109,18 @@ class Server(threading.Thread):
                 # Broadcast the message to everyone <sending the packet
                 self.broadcast(packet)
 
+
+            # Let's make the closing statement a function
             except:
-                # Removing And Closing Clients
-                index = self.clients.index(client)
-                self.clients.remove(client)
-                client.close()
-                user = self.usernames[index]
-                self.broadcast('{} left!'.format(user).encode('ascii'))
-                self.usernames.remove(user)
+
+                handle_client_leave()
+                # # Removing And Closing Clients
+                # index = self.clients.index(client)
+                # self.clients.remove(client)
+                # client.close()
+                # user = self.usernames[index]
+                # self.broadcast('{} left!'.format(user).encode('ascii'))
+                # self.usernames.remove(user)
                 break
 
 
@@ -139,6 +172,9 @@ class Server(threading.Thread):
 
         except Exception as e:
             logger.error(f"Error during server_start() excution: {e}")
+
+
+
 
 # Parameters:  ---hostname <address : Str> --port <port : int> --maxconns <max connections : int> --messagelength <message length: int>
 # Running:      $ python3.13 server.py --hostname localhost --port 8888 --maxconns 32 --messagelength 64

--- a/src/utils/interface.py
+++ b/src/utils/interface.py
@@ -13,10 +13,14 @@ from pathlib import Path
 
 
 # Implemented IRC Commands (useful if desired parsing by array)
-commands = {"/sh", "/esh", "/servers", "/users", "/current", "/whisper", 
+def get_commands():
+    
+    commands = {"/sh", "/esh", "/servers", "/users", "/current", "/whisper", 
             "/join", "/accept", "/reject", "/leave", "/delete", 
             "/accept", "/reject", "/sendfile", "/receivefile", 
             "/off", "/commands"}
+
+    return commands
 
 # Global Text Section
 def get_command_text() -> str:

--- a/src/utils/interface.py
+++ b/src/utils/interface.py
@@ -46,28 +46,6 @@ def print_commands():
 
     print(get_command_text())
 
-    # print("\nWelcome to the eIRC Shell!")
-    # print("Type:")
-    # print("\t/sh: to enter shell mode and exit IRC mode.")
-    # print("\t/esh: to exit shell mode and enter into IRC mode.")
-    # print("\t/servers: to list active servers you're in.")
-    # print("\t/users: to list active users in your friends list.")
-    # print("\t/current: prints current channel.")
-    # print("\t/whisper <user>: to send direct message to user.")
-    # print("\t/join <server> <key>: to join private server.")
-    # print("\t/accept <server>: to accept server invitation.")
-    # print("\t/reject <server>: to reject server invitation.")
-    # print("\t/leave <server>: to leave server.")
-    # print("\t/delete <user>: to delete user from friends list.")
-    # print("\t/accept <user>: to accept user friend request.")
-    # print("\t/reject <user>: to reject user friend request.")
-    # print("\t/sendfile filepath <user>: to send file to user -- End user must accept sendfile request.")
-    # print("\t/receivefile <user>: to accept file request from user.")
-    # print("\t/off: to close IRC client.")
-    # print("\t/commands: to list all eIRC commands.")
-    # print("\nEnjoy.")
-
-
 # Interface, can swap between IRC and Shell mode
 def interface():
 
@@ -194,3 +172,38 @@ def interface():
 if __name__ == "__main__":
 
     interface()
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    # print("\nWelcome to the eIRC Shell!")
+    # print("Type:")
+    # print("\t/sh: to enter shell mode and exit IRC mode.")
+    # print("\t/esh: to exit shell mode and enter into IRC mode.")
+    # print("\t/servers: to list active servers you're in.")
+    # print("\t/users: to list active users in your friends list.")
+    # print("\t/current: prints current channel.")
+    # print("\t/whisper <user>: to send direct message to user.")
+    # print("\t/join <server> <key>: to join private server.")
+    # print("\t/accept <server>: to accept server invitation.")
+    # print("\t/reject <server>: to reject server invitation.")
+    # print("\t/leave <server>: to leave server.")
+    # print("\t/delete <user>: to delete user from friends list.")
+    # print("\t/accept <user>: to accept user friend request.")
+    # print("\t/reject <user>: to reject user friend request.")
+    # print("\t/sendfile filepath <user>: to send file to user -- End user must accept sendfile request.")
+    # print("\t/receivefile <user>: to accept file request from user.")
+    # print("\t/off: to close IRC client.")
+    # print("\t/commands: to list all eIRC commands.")
+    # print("\nEnjoy.")

--- a/src/utils/tracker.py
+++ b/src/utils/tracker.py
@@ -129,7 +129,7 @@ class ServerTracker(Tracker):
     
     # Adds a new chat server to the directory and grants initial administrative rights
 
-    # NOTE: server_address will contain IP:PORT
+    # NOTE: server_address will contain 'IP:PORT'
     def register_server(self, server_name: str, server_address: str,
                         admin_user: str, admin_address: str,
                         is_private: bool, passkey: str):


### PR DESCRIPTION
Allows client to seamlessly join and leave chat rooms.

NOTE: It is required further object encapsulation of client and interface models such as to allow clients to leave the current tracker instance and hop back into an interface.

userusage are as follows: starts interface -> initiates tracker connection -> create/join/send (eIRC commands) -> if in chat room allow users to leave chat room -> hop back to tracker <-- currently here -> allow user to back out of tracker instance and back into pure interface mode (requires client-side implementation)