### PR TITLE
Clients can use /leave to leave chat rooms and /exit to exit from tracker server successfully

### DIFF
--- a/src/utils/interface.py
+++ b/src/utils/interface.py
@@ -17,7 +17,7 @@ def get_commands():
     
     commands = {"/sh", "/esh", "/servers", "/users", "/current", "/whisper", 
             "/join", "/accept", "/reject", "/leave", "/delete", 
-            "/accept", "/reject", "/sendfile", "/receivefile", 
+            "/reject", "/sendfile", "/receivefile", 
             "/off", "/commands"}
 
     return commands
@@ -176,38 +176,4 @@ def interface():
 if __name__ == "__main__":
 
     interface()
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    # print("\nWelcome to the eIRC Shell!")
-    # print("Type:")
-    # print("\t/sh: to enter shell mode and exit IRC mode.")
-    # print("\t/esh: to exit shell mode and enter into IRC mode.")
-    # print("\t/servers: to list active servers you're in.")
-    # print("\t/users: to list active users in your friends list.")
-    # print("\t/current: prints current channel.")
-    # print("\t/whisper <user>: to send direct message to user.")
-    # print("\t/join <server> <key>: to join private server.")
-    # print("\t/accept <server>: to accept server invitation.")
-    # print("\t/reject <server>: to reject server invitation.")
-    # print("\t/leave <server>: to leave server.")
-    # print("\t/delete <user>: to delete user from friends list.")
-    # print("\t/accept <user>: to accept user friend request.")
-    # print("\t/reject <user>: to reject user friend request.")
-    # print("\t/sendfile filepath <user>: to send file to user -- End user must accept sendfile request.")
-    # print("\t/receivefile <user>: to accept file request from user.")
-    # print("\t/off: to close IRC client.")
-    # print("\t/commands: to list all eIRC commands.")
-    # print("\nEnjoy.")
+    

--- a/src/utils/tracker.py
+++ b/src/utils/tracker.py
@@ -161,9 +161,9 @@ class ChatTracker(Tracker):
         self.remove_member(user)
 
     # Returns all active users
-    def list_active_users(self) -> dict: 
+    def get_active_users_list(self) -> dict: 
         return self.list_members()
 
     # Returns current chat administrators
-    def list_admins(self) -> dict:
+    def get_admin_list(self) -> dict:
         return super().list_admins()


### PR DESCRIPTION
TODO: The file descriptor <socket> is still opened after /exit, this must be managed Client-side.

Given that the Client will have a Shell Interface and a IRC interface, when they /exit from the tracker (the IRC mode) they shall enter into the default state of the interface which enables them to once again open a <socket> fd for connection into the tracker, all of this must be implemented Client side